### PR TITLE
Fix to remove the InsecureRequestWarning message

### DIFF
--- a/hash.py
+++ b/hash.py
@@ -5,6 +5,7 @@ import os
 import requests
 import argparse
 import concurrent.futures
+import urllib3
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-s', help='hash', dest='hash')
@@ -31,6 +32,7 @@ cwd = os.getcwd()
 directory = args.dir
 file = args.file
 thread_count = args.threads or 4
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 if directory:
     if directory[-1] == '/':


### PR DESCRIPTION
A little fix to disable this message :

InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.nitrxgen.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings